### PR TITLE
Replaces deprecated lodash-builder dependency and grunt task with lodash

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -230,7 +230,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-lodashbuilder');
+    grunt.loadNpmTasks('grunt-lodash');
     grunt.loadNpmTasks('grunt-contrib-jasmine');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-copy');
@@ -241,7 +241,7 @@ module.exports = function(grunt) {
 
         var cfg = {
             modules: grunt.file.expand({ cwd: 'dist/' }, config.moduleSources.join(' ').replace(/src\//g, '').split(' ') )
-        }
+        };
 
         grunt.file.write('test/requirejs.spec.helper.js', 'var cfg = ' + JSON.stringify( cfg ) + ';' );
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-copy": "0.x.x",
     "grunt-contrib-jshint": "0.x.x",
     "grunt-contrib-watch": "~0.3.1",
-    "grunt-lodashbuilder": "~0.1.7",
+    "grunt-lodash": "~0.3.0",
     "grunt-template-jasmine-requirejs": "~0.1.1"
   },
   "bundledDependencies": [],


### PR DESCRIPTION
npm install was crapping out for me due to outdated dependency...
unless there is some good reason for keeping the lodash-builder, this updates the dependency and gruntfile reference
