### PR TITLE
change the value of angleIndicator to make it work in ie11

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -99,7 +99,7 @@ require({
                     strokeStyle: 'hsla(60, 37%, 17%, 1)',
                     lineWidth: 1,
                     fillStyle: 'hsla(60, 47%, 37%, 0.8)',
-                    angleIndicator: 'none'
+                    angleIndicator: 'hsla(0, 0%, 0%, 0)'
                 }
             }
         })


### PR DESCRIPTION
"none" is a invalid value to strokeStyle in ie,so black will be automatically set to strokeStyle.In other browsers "none" is legal and equal to "hsla(0, 0%, 0%, 0)".So I think "hsla(0, 0%, 0%, 0)" may be more appropriate here.
