### PR TITLE
fix the problem that world.render sometimes renders body to wrong positi...

### DIFF
--- a/dist/physicsjs-full-0.5.1.js
+++ b/dist/physicsjs-full-0.5.1.js
@@ -8250,11 +8250,14 @@ Physics.renderer('canvas', function( proto ){
                 ,aabb = body.aabb()
                 ;
 
-            ctx.save();
-            ctx.translate(pos.get(0) + offset.get(0), pos.get(1) + offset.get(1));
-            ctx.rotate(body.state.angular.pos);
-            ctx.drawImage(view, -view.width/2, -view.height/2);
-            ctx.restore();
+            view.onload = function () {
+                view.onload = null;
+                ctx.save();
+                ctx.translate(pos.get(0) + offset.get(0), pos.get(1) + offset.get(1));
+                ctx.rotate(body.state.angular.pos);
+                ctx.drawImage(view, -view.width / 2, -view.height / 2);
+                ctx.restore();
+            };
 
             if ( this.options.debug ){
                 // draw bounding boxes


### PR DESCRIPTION
...on in ie11

When the 2D context draws a image which isn't loaded,image.width and image.height are zero,then context will draw this image to wrong position.Some browsers like chrome are very fast and the image always has loaded using ctx.drawImage(view, -view.width / 2, -view.height / 2).But ie is so slow that we have to add a explicit onload function.
