### PR TITLE
fix the problem that sometimes the body been rendered in the wrong posit...

### DIFF
--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -273,6 +273,8 @@ Physics.renderer('canvas', function( proto ){
             hiddenCtx.restore();
 
             view.src = hiddenCanvas.toDataURL("image/png");
+            view.width = hiddenCanvas.width;
+            view.height = hiddenCanvas.height;
             return view;
         },
 


### PR DESCRIPTION
...ion in ie11

I have already tested the code and it works well in ie.
I don't know whether to add two temporary variables to store the values of "2 \* hw + 2 + (2 \* styles.lineWidth|0)" and "2 \* hh + 2 + (2 \* styles.lineWidth|0)",then assign them to hiddenCanvas.width,hiddenCanvas.height,view.width and view.height for improving a little performance.
