### PR TITLE
Initialize with window object to fix browserify bundling

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -9,7 +9,7 @@
         // Browser globals (root is window)
         root.Physics = factory.call(root);
     }
-}(window, function () {
+}(typeof window !== 'undefined' ? window : this, function () {
 
 'use strict';
 


### PR DESCRIPTION
Hello Jasper,

I've been trying to use PhysicsJS with browserify and ran into a problem - when the wrapper function is called by the browserify bundler, the `this` context is not `window` as is assumed by the current code. It ends up causing `window` to be set to some browserify state and `document` to be undefined. Explicitly passing in `window` instead of `this` fixes it for me.

Here are some similar issues on other projects I've found while debugging:

https://github.com/ractivejs/ractive/issues/122
https://github.com/EightMedia/hammer.js/pull/429

This seems like an easy enough fix but I don't know if it breaks anything else - let me know if you've got a better suggestion. Thanks!

-Dan
