### PR TITLE
support multi-touch

### DIFF
--- a/src/behaviors/interactive.js
+++ b/src/behaviors/interactive.js
@@ -251,7 +251,9 @@ Physics.behavior('interactive', function( parent ){
                         delete self.contactPointsOld[touchId];
                         delete self.offsets[touchId];
                         delete self.bodies[touchId];
-                        delete body.isGrabbed;
+                        if (body) {
+                          delete body.isGrabbed;
+                        }
                     }
                     
                 }


### PR DESCRIPTION
Updates "interaction" behavior to support multi-touch events. Everything is backwards compatible, so there's very little changed from a user perspective, other than the fact that putting more than one finger on various objects on a multi-touch device will grab and move them all.

These are the only other changes:
- `body.isGrabbed` is set to `true` while bodies are grabbed
- The "release" event is emitted before the body is destroyed (rather than after), so `data.body` is available in any listeners.

The "interact:" events are emitted once for each pointer (mouse, finger, pen, etc.).

I tested in IE11 and Chrome and in normal desktop browser with normal mouse and multi-touch mouse using hammer.js multi-touch shimming. I don't know the full range of browser support, but everything should degrade nicely.

I had one other thought, which I can do if you want, but it would not be fully backwards compatible: When there is no body on release, it could emit "interact:unpoke" instead of "interact:release". That would mirror what happens on grab/poke.
