### PR TITLE
Use require instead of global for browserify

### DIFF
--- a/src/renderers/pixi-renderer.js
+++ b/src/renderers/pixi-renderer.js
@@ -74,14 +74,21 @@
  * ```
  **/
 /* global PIXI */
-if (!PIXI && require){
-    var PIXI = require('pixi.js');
-}
 Physics.renderer('pixi', function( parent ){
 
     if ( !document ){
         // must be in node environment
         return {};
+    }
+    
+    // no pixi
+    if (!PIXI){
+        if (require){
+            // browserify, node-webkit, or requirejs
+            var PIXI = require('pixi.js');
+        }else{
+            return {};
+        }
     }
 
     var Pi2 = Math.PI * 2


### PR DESCRIPTION
I am using browserify, and I use `var PIXI = require('pixi.js')` in any file I need it. This code keeps everything the same, but allows me to not have to inject a PIXI global in the scope.
