### PR TITLE
check for window.performance.timing existance

### DIFF
--- a/src/util/ticker.js
+++ b/src/util/ticker.js
@@ -14,7 +14,7 @@
 
     function now(){
         // http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision
-        return (perf && perf.now) ?
+        return (perf && perf.now && perf.timing) ?
             (perf.now() + perf.timing.navigationStart) :
             Date.now();
     }


### PR DESCRIPTION
Apparently [cocoonjs](https://www.ludei.com/cocoonjs) does not support window.performance.timing. 
This issue prohibits physics js from running on  cocoon